### PR TITLE
use 'scikit-learn' rather than 'sklearn'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = "^3.7.1"
-sklearn = "^0.0"
+scikit-learn = "^1.5.2"
 pandas = "^1.2.2"
 rich = "^10.13.0"
 


### PR DESCRIPTION
The 'sklearn' PyPI package is deprecated, use 'scikit-learn', rather than 'sklearn' for pip commands.